### PR TITLE
#50, #51: ログイン時のアイコン切り替えを実装完了

### DIFF
--- a/components/UI/Header.vue
+++ b/components/UI/Header.vue
@@ -121,7 +121,7 @@
 
       <!-- ログイン中の設定 -->
       <v-menu
-        v-if="loggedIn"
+
         open-on-hover
         bottom
         offset-y>
@@ -131,8 +131,8 @@
             v-bind="attrs"
             v-on="on"
           >
-          <v-avatar size="40" style="margin: 3px 5% 0 0;">
-            <v-img src="https://randomuser.me/api/portraits/men/1.jpg" />
+          <v-avatar v-show="loggedIn" size="40" style="margin: 3px 5% 0 0;">
+            <v-img :src="userImage ? userImage : '/images/cafe.jpeg'" />
           </v-avatar>
           </v-btn>
         </template>
@@ -160,14 +160,13 @@
 
       <!-- 未ログインの表示 -->
       <v-menu
-      v-else
       open-on-hover
       bottom
       left
       offset-y
       >
         <template v-slot:activator="{ on, attrs }">
-          <div class="account-menu" v-bind="attrs"
+          <div v-show="!loggedIn" class="account-menu" v-bind="attrs"
             v-on="on">|  アカウント  |</div>
         </template>
         <v-card width="280px">
@@ -248,10 +247,10 @@ export default {
   computed: {
     ...mapGetters({
       user: 'auth/user',
+      userImage: 'auth/userImage',
       loggedIn: 'auth/authStatus'
     })
   },
-
 }
 </script>
 

--- a/plugins/firebase.auth.js
+++ b/plugins/firebase.auth.js
@@ -11,14 +11,28 @@ export default (context) => {
     auth.onAuthStateChanged(user => {
       // ** ログイン済のユーザー
       if (user) {
-        // ログイン済みユーザーの情報保持
-        const users = {}
+        let users = {}
         users.uid = user.uid
-        
+
+        // usersコレクションのインタスタンス作成
+        const userRef = db.collection('users').doc(user.uid)
+        let userImage = {}
+        userRef.get().then(doc => {
+          // users = doc.data().images.src
+          if (doc.data().image.src) {
+            userImage.image = doc.data().image.src
+            store.commit('auth/setUserImage', userImage.image)
+          } else {
+            userImage.image = doc.data().image
+            store.commit('auth/setUserImage', userImage.image)
+          }
+        })
+
         let authStatus = true
         store.commit('auth/setUser', users)
         store.commit('auth/setAuthStatus', authStatus)
-        resolve(users)
+        resolve( users )
+
       } else {
         // ** ログインしていないユーザーもしくは認証が切れている
         let authStatus = false

--- a/store/auth.js
+++ b/store/auth.js
@@ -7,6 +7,7 @@ import { db, auth } from '~/plugins/firebase.js'
 // userStatus: true or false
 export const state = () => ({
   user: null,
+  userImage:null,
   authStatus: false,
   errorMessage: '  ',
 })
@@ -14,6 +15,10 @@ export const state = () => ({
 export const mutations = {
   setUser(state, payload) {
     state.user = payload
+  },
+
+  setUserImage(state, payload) {
+    state.userImage = payload
   },
 
   setAuthStatus(state, payload) {
@@ -26,10 +31,6 @@ export const mutations = {
 }
 
 export const actions = {
-  setUsers({commit}, payload) {
-
-  },
-
   // Mailでの新規ユーザー登録, ユーザー情報取得
   signUp({ commit }, { email, password }) {
     return auth.setPersistence(firebase.auth.Auth.Persistence.LOCAL).then(() => {
@@ -206,6 +207,9 @@ export const actions = {
 export const getters = {
   user(state) {
     return state.user
+  },
+  userImage(state) {
+    return state.userImage
   },
   authStatus(state) {
     return state.authStatus


### PR DESCRIPTION
closed #50 

### 難しかった点
 - コンポーネントかつ、layoutでの利用をしているHeaderにて、非同期データをリストバインディングする。
 - 尚且つ、v-showで切り替えも必要

### 主な問題点
 - 非同期処理をコンポーネントに直接書いても使用できない（仕様上そうなっている）
 - かと言って、公式の推奨している親pagesファイルにてasyncdataで非同期通信、データをpropsで受け渡しするという方法は使用できない　→　Headerは、layouts の default.vue のコンポーネントとして使用しているから

### 解決方法
色々やり方はあるだろうけど、今回はVuexを中心に設計することで達成
→　ポイントは非同期処理の取得時間（なので今後データ量が増えたときに不安ではある）

 - pluginでそもそもログイン状態を監視していた。
→　ここにログインしているユーザーuidを基にusersコレクションを検索し、該当するユーザーデータから、このアプリ内で登録しているイメージ画像を取得するメソッドを追加する。
→　ここがポイント『取得して直ぐにVuexへcommit してデータを渡す』。これを入れてからスムーズに描画された。